### PR TITLE
fix typo

### DIFF
--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "BubbelCord",
+    "name": "BubbleCord",
     "description": "makes discord have a bubble feel",
     "version": "1.3",
     "author": "Doggybootsy#1333",


### PR DESCRIPTION
on the manifest the theme was names bubbelcord instead of bubblecord